### PR TITLE
Add FastAPI backend and Kubernetes setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ curl -X POST http://localhost:3000/api/session
 Use the returned session cookie for subsequent requests. A WebSocket connection can be opened at `ws://localhost:3000/ws` with the session cookie.
 
 The server exposes a simple health check at `/health` that returns `OK`.
+
+## Kubernetes setup
+
+Run `scripts/start.sh` to launch PostgreSQL, Redis and the FastAPI backend in Minikube using Helm. Use `scripts/stop.sh` to tear it down.

--- a/backend/analytics.py
+++ b/backend/analytics.py
@@ -1,0 +1,33 @@
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import func
+from .database import SessionLocal
+from . import models
+from datetime import date
+
+
+def connections_per_mood(db: Session):
+    return db.query(models.Event.mood, func.count()).group_by(models.Event.mood).all()
+
+
+def daily_resonance_counts(db: Session):
+    return (
+        db.query(func.date(models.Event.created_at), func.count())
+        .group_by(func.date(models.Event.created_at))
+        .all()
+    )
+
+
+def common_themes(db: Session):
+    return db.query(models.Event.symbol, func.count()).group_by(models.Event.symbol).order_by(func.count().desc()).limit(5).all()
+
+
+def gather_stats():
+    db = SessionLocal()
+    try:
+        return {
+            "mood_counts": connections_per_mood(db),
+            "daily": daily_resonance_counts(db),
+            "themes": common_themes(db),
+        }
+    finally:
+        db.close()

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,10 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+import os
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://luma:luma@localhost:5432/luma")
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,53 @@
+from fastapi import FastAPI, Depends
+from fastapi.middleware.cors import CORSMiddleware
+from .database import Base, engine, SessionLocal
+from .routers import events, matching, resonance
+from .middleware import PremiumMiddleware
+from . import models
+import uuid
+import aioredis
+
+app = FastAPI()
+app.add_middleware(PremiumMiddleware)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+Base.metadata.create_all(bind=engine)
+
+redis = aioredis.from_url("redis://localhost")
+
+app.include_router(events.router)
+app.include_router(matching.router)
+app.include_router(resonance.router)
+
+@app.post("/session")
+async def create_session():
+    token = str(uuid.uuid4())
+    db = SessionLocal()
+    try:
+        sess = models.Session(token=token)
+        db.add(sess)
+        db.commit()
+    finally:
+        db.close()
+    return {"token": token}
+
+@app.websocket("/ws/presence/{event_id}")
+async def websocket_endpoint(websocket, event_id: int):
+    await websocket.accept()
+    await redis.incr(f"event:{event_id}:count")
+    try:
+        while True:
+            count = int(await redis.get(f"event:{event_id}:count"))
+            await websocket.send_json({"count": count})
+            await websocket.receive_text()
+    except Exception:
+        pass
+    finally:
+        await redis.decr(f"event:{event_id}:count")
+        await websocket.close()

--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -1,0 +1,27 @@
+from fastapi import Request, HTTPException
+from starlette.middleware.base import BaseHTTPMiddleware
+from sqlalchemy.orm import Session
+from .database import SessionLocal
+from .models import PremiumFeature, Session as DBSession
+
+PREMIUM_ENDPOINTS = {"/resonance/link", "/mood"}
+
+class PremiumMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app):
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path in PREMIUM_ENDPOINTS:
+            token = request.query_params.get("session_token")
+            if not token:
+                raise HTTPException(status_code=403, detail="premium access required")
+            db: Session = SessionLocal()
+            try:
+                session = db.query(DBSession).filter_by(token=token).first()
+                has_feature = db.query(PremiumFeature).filter_by(session_id=session.id).first() if session else None
+            finally:
+                db.close()
+            if not has_feature:
+                raise HTTPException(status_code=403, detail="premium feature")
+        response = await call_next(request)
+        return response

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,38 @@
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Text
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+from .database import Base
+
+class Session(Base):
+    __tablename__ = "sessions"
+    id = Column(Integer, primary_key=True, index=True)
+    token = Column(String, unique=True, index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+class Event(Base):
+    __tablename__ = "events"
+    id = Column(Integer, primary_key=True, index=True)
+    creator_id = Column(Integer, ForeignKey("sessions.id"))
+    mood = Column(String, nullable=True)
+    symbol = Column(String, nullable=True)
+    content = Column(Text, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    session = relationship("Session")
+
+class PremiumFeature(Base):
+    __tablename__ = "premium_features"
+    id = Column(Integer, primary_key=True)
+    session_id = Column(Integer, ForeignKey("sessions.id"))
+    feature_name = Column(String)
+
+class SilentLink(Base):
+    __tablename__ = "silent_links"
+    id = Column(Integer, primary_key=True)
+    session_a = Column(Integer, ForeignKey("sessions.id"))
+    session_b = Column(Integer, ForeignKey("sessions.id"))
+
+class Mood(Base):
+    __tablename__ = "moods"
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True)
+    lottie_file = Column(String)

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from .. import models, schemas
+from ..database import SessionLocal
+import uuid
+
+router = APIRouter(prefix="/events", tags=["events"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@router.post("/", response_model=schemas.EventOut)
+def create_event(event: schemas.EventCreate, session_token: str, db: Session = Depends(get_db)):
+    session = db.query(models.Session).filter_by(token=session_token).first()
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    db_event = models.Event(**event.dict(), creator_id=session.id)
+    db.add(db_event)
+    db.commit()
+    db.refresh(db_event)
+    return db_event
+
+@router.get("/", response_model=list[schemas.EventOut])
+def list_events(db: Session = Depends(get_db)):
+    return db.query(models.Event).all()
+
+@router.get("/{event_id}", response_model=schemas.EventOut)
+def get_event(event_id: int, db: Session = Depends(get_db)):
+    event = db.query(models.Event).get(event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+    return event
+
+@router.delete("/{event_id}")
+def delete_event(event_id: int, db: Session = Depends(get_db)):
+    event = db.query(models.Event).get(event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+    db.delete(event)
+    db.commit()
+    return {"detail": "deleted"}

--- a/backend/routers/matching.py
+++ b/backend/routers/matching.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from .. import models
+from ..database import SessionLocal
+import random
+
+router = APIRouter(prefix="/match", tags=["match"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@router.get("/")
+def match_events(session_token: str, db: Session = Depends(get_db)):
+    session = db.query(models.Session).filter_by(token=session_token).first()
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    events = db.query(models.Event).filter(models.Event.creator_id != session.id).all()
+    random.shuffle(events)
+    return events[:3]

--- a/backend/routers/resonance.py
+++ b/backend/routers/resonance.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from .. import models
+from ..database import SessionLocal
+
+router = APIRouter(prefix="/resonance", tags=["resonance"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@router.post("/link")
+def create_link(session_token: str, target_token: str, db: Session = Depends(get_db)):
+    session = db.query(models.Session).filter_by(token=session_token).first()
+    target = db.query(models.Session).filter_by(token=target_token).first()
+    if not session or not target:
+        raise HTTPException(status_code=404, detail="Session not found")
+    link = models.SilentLink(session_a=session.id, session_b=target.id)
+    db.add(link)
+    db.commit()
+    return {"detail": "linked"}
+
+@router.get("/links")
+def list_links(session_token: str, db: Session = Depends(get_db)):
+    session = db.query(models.Session).filter_by(token=session_token).first()
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    links = db.query(models.SilentLink).filter(
+        (models.SilentLink.session_a == session.id) | (models.SilentLink.session_b == session.id)
+    ).all()
+    return links

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,0 +1,35 @@
+CREATE TABLE sessions (
+    id SERIAL PRIMARY KEY,
+    token VARCHAR(255) UNIQUE NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE events (
+    id SERIAL PRIMARY KEY,
+    creator_id INTEGER REFERENCES sessions(id),
+    mood VARCHAR(50),
+    symbol VARCHAR(50),
+    content TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE premium_features (
+    id SERIAL PRIMARY KEY,
+    session_id INTEGER REFERENCES sessions(id),
+    feature_name VARCHAR(50)
+);
+
+CREATE TABLE silent_links (
+    id SERIAL PRIMARY KEY,
+    session_a INTEGER REFERENCES sessions(id),
+    session_b INTEGER REFERENCES sessions(id)
+);
+
+CREATE TABLE moods (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(50) UNIQUE,
+    lottie_file VARCHAR(255)
+);
+
+CREATE INDEX idx_events_mood ON events(mood);
+CREATE INDEX idx_events_created ON events(created_at);

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class SessionCreate(BaseModel):
+    pass
+
+class SessionOut(BaseModel):
+    token: str
+
+class EventCreate(BaseModel):
+    mood: Optional[str]
+    symbol: Optional[str]
+    content: str
+
+class EventOut(EventCreate):
+    id: int
+    creator_id: int
+    created_at: str
+
+    class Config:
+        orm_mode = True

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -1,0 +1,15 @@
+# Kubernetes Setup
+
+Use the provided Helm chart to deploy all components:
+
+- FastAPI backend
+- PostgreSQL
+- Redis
+
+Install with:
+
+```bash
+helm install luma helm/luma
+```
+
+Expose the service using port-forward or ingress. The chart is suitable for local Minikube clusters.

--- a/docs/matching_algorithm.py
+++ b/docs/matching_algorithm.py
@@ -1,0 +1,11 @@
+"""Soft matching algorithm pseudocode."""
+import random
+
+def select_events(user_session, redis_conn, db):
+    recent = redis_conn.get(f"recent:{user_session}")
+    candidates = db.query(Event).filter(Event.id.notin_(recent)).all()
+    random.shuffle(candidates)
+    emotionally_relevant = [e for e in candidates if resonates(user_session, e)]
+    events = emotionally_relevant[:3]
+    redis_conn.set(f"recent:{user_session}", [e.id for e in events], ex=300)
+    return events

--- a/docs/mobile_integration.md
+++ b/docs/mobile_integration.md
@@ -1,0 +1,6 @@
+# Mobile App Integration
+
+Luma's React frontend can be wrapped in a native shell using Capacitor or React Native Web.
+Silent notifications are handled via platform push services with no sound flag set.
+Background tasks can fetch resonance updates using periodic timers.
+Animations for mood customization can leverage native Lottie libraries.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,20 @@
+# Privacy and Anonymity
+
+Luma avoids storing personal data. Sessions are tracked only by random tokens.
+Premium features are linked to sessions, not identities.
+
+```python
+# secure session creation example
+from uuid import uuid4
+from fastapi import Response
+
+def create_session(response: Response, db):
+    token = str(uuid4())
+    db.add(Session(token=token))
+    db.commit()
+    response.set_cookie("session_token", token, httponly=True, secure=True)
+    return {"token": token}
+```
+
+Events expire automatically using PostgreSQL's `ttl`/cron jobs.
+A scheduled task deletes events older than 30 days.

--- a/docs/websocket_presence.md
+++ b/docs/websocket_presence.md
@@ -1,0 +1,30 @@
+# Real-time Presence
+
+FastAPI WebSocket endpoint broadcasts the current participant count using Redis.
+A simple React hook connects to the socket and updates UI.
+
+```python
+@app.websocket("/ws/presence/{event_id}")
+async def presence(ws: WebSocket, event_id: int):
+    await ws.accept()
+    await redis.incr(f"event:{event_id}:count")
+    try:
+        while True:
+            await ws.receive_text()
+            count = int(await redis.get(f"event:{event_id}:count"))
+            await ws.send_json({"count": count})
+    finally:
+        await redis.decr(f"event:{event_id}:count")
+```
+
+```jsx
+function usePresence(eventId) {
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    const ws = new WebSocket(`/ws/presence/${eventId}`);
+    ws.onmessage = (e) => setCount(JSON.parse(e.data).count);
+    return () => ws.close();
+  }, [eventId]);
+  return count;
+}
+```

--- a/helm/luma/Chart.yaml
+++ b/helm/luma/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: luma
+version: 0.1.0

--- a/helm/luma/templates/backend-deployment.yaml
+++ b/helm/luma/templates/backend-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: luma-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: luma-backend
+  template:
+    metadata:
+      labels:
+        app: luma-backend
+    spec:
+      containers:
+      - name: backend
+        image: {{ .Values.image }}
+        ports:
+        - containerPort: 8000
+        env:
+        - name: DATABASE_URL
+          value: postgresql://luma:luma@postgres:5432/luma
+        - name: REDIS_URL
+          value: redis://redis:6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: luma-backend
+spec:
+  selector:
+    app: luma-backend
+  ports:
+  - port: 80
+    targetPort: 8000

--- a/helm/luma/templates/ingress.yaml
+++ b/helm/luma/templates/ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: luma-ingress
+spec:
+  rules:
+  - host: luma.local
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: luma-backend
+            port:
+              number: 80

--- a/helm/luma/templates/postgres.yaml
+++ b/helm/luma/templates/postgres.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: {{ .Values.postgres.image }}
+        env:
+        - name: POSTGRES_DB
+          value: luma
+        - name: POSTGRES_USER
+          value: luma
+        - name: POSTGRES_PASSWORD
+          value: luma
+        ports:
+        - containerPort: 5432
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+  - port: 5432
+    targetPort: 5432

--- a/helm/luma/templates/redis.yaml
+++ b/helm/luma/templates/redis.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: {{ .Values.redis.image }}
+        ports:
+        - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  selector:
+    app: redis
+  ports:
+  - port: 6379
+    targetPort: 6379

--- a/helm/luma/values.yaml
+++ b/helm/luma/values.yaml
@@ -1,0 +1,5 @@
+image: luma-backend:latest
+postgres:
+  image: postgres:15
+redis:
+  image: redis:7

--- a/public/components/MoodVisualizer.jsx
+++ b/public/components/MoodVisualizer.jsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import Lottie from 'lottie-web';
+
+const moodFiles = {
+  rain: '/moods/rain.json',
+  sun: '/moods/sun.json',
+  waves: '/moods/waves.json',
+  fog: '/moods/fog.json'
+};
+
+export default function MoodVisualizer({ mood }) {
+  useEffect(() => {
+    const anim = Lottie.loadAnimation({
+      container: document.getElementById('mood-canvas'),
+      renderer: 'svg',
+      loop: true,
+      autoplay: true,
+      path: moodFiles[mood] || moodFiles.rain
+    });
+    return () => anim.destroy();
+  }, [mood]);
+  return <div id="mood-canvas" style={{width:'100%',height:'100%'}}></div>;
+}

--- a/public/components/PresenceIndicator.jsx
+++ b/public/components/PresenceIndicator.jsx
@@ -1,0 +1,11 @@
+import { useEffect, useState } from 'react';
+
+export default function PresenceIndicator({ eventId }) {
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    const ws = new WebSocket(`/ws/presence/${eventId}`);
+    ws.onmessage = (e) => setCount(JSON.parse(e.data).count);
+    return () => ws.close();
+  }, [eventId]);
+  return <span>{count} resonating</span>;
+}

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+minikube start
+helm install luma ../helm/luma

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+helm uninstall luma
+minikube stop


### PR DESCRIPTION
## Summary
- implement basic FastAPI backend with anonymous sessions, event CRUD, matching and resonance endpoints
- add PostgreSQL schema and SQLAlchemy models
- include middleware for premium feature gating
- provide analytics helpers and WebSocket presence support
- document privacy, mobile integration, infrastructure, and matching algorithm
- add React components for mood visualization and presence indicator
- supply Helm chart for FastAPI, PostgreSQL and Redis
- add scripts to start and stop local Minikube stack
- update README with new Kubernetes instructions
