### PR TITLE
feat(frontend): scaffold PWA with basic routes

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  extends: ['eslint:recommended', 'plugin:react/recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['react', '@typescript-eslint'],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  rules: {},
+};

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Luma PWA</title>
+  </head>
+  <body class="bg-dawnSand dark:bg-nightBlue text-black dark:text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "luma-pwa",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.3.0",
+    "zustand": "^4.4.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^4.9.3",
+    "vite": "^4.0.0",
+    "tailwindcss": "^3.3.2",
+    "postcss": "^8.4.21",
+    "autoprefixer": "^10.4.13",
+    "eslint": "^8.44.0",
+    "prettier": "^2.8.4"
+  }
+}

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import { Outlet } from 'react-router-dom';
+import { useSession } from './store/session';
+
+export default function App() {
+  const initSession = useSession((s) => s.initSession);
+
+  useEffect(() => {
+    initSession();
+  }, [initSession]);
+
+  return (
+    <div className="min-h-screen bg-dawnSand dark:bg-nightBlue text-gray-800 dark:text-gray-100">
+      <Outlet />
+    </div>
+  );
+}

--- a/frontend/src/api/ws.ts
+++ b/frontend/src/api/ws.ts
@@ -1,0 +1,3 @@
+export function connect(url: string): WebSocket {
+  return new WebSocket(url);
+}

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,8 @@
+export default function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center p-8 opacity-70">
+      <p>No events right now.</p>
+      {/* TODO: insert Lottie loop */}
+    </div>
+  );
+}

--- a/frontend/src/components/EventCard.tsx
+++ b/frontend/src/components/EventCard.tsx
@@ -1,0 +1,26 @@
+import { FC } from 'react';
+
+interface EventCardProps {
+  symbol: string;
+  text: string;
+  expiresIn: number;
+  onSendEnergy: () => void;
+}
+
+export const EventCard: FC<EventCardProps> = ({
+  symbol,
+  text,
+  expiresIn,
+  onSendEnergy,
+}) => (
+  <button
+    className="rounded-2xl shadow-sm bg-dawnSand dark:bg-nightBlue/20 p-6 w-full text-left flex items-center space-x-3"
+    onClick={onSendEnergy}
+  >
+    <span className="text-3xl">{symbol}</span>
+    <div className="flex-1">
+      <p className="font-semibold">{text}</p>
+      <p className="text-xs opacity-70">{Math.ceil(expiresIn / 60)}m left</p>
+    </div>
+  </button>
+);

--- a/frontend/src/features/create-event/CreateEvent.tsx
+++ b/frontend/src/features/create-event/CreateEvent.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function CreateEvent() {
+  const [text, setText] = useState('');
+  const [duration, setDuration] = useState(1);
+  const navigate = useNavigate();
+
+  const submit = async () => {
+    const res = await fetch('/api/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, duration: duration * 3600, mood: 'rain' }),
+    });
+    if (res.ok) {
+      const { eventId } = await res.json();
+      navigate(`/energy/${eventId}`);
+    }
+  };
+
+  return (
+    <div role="dialog" className="p-4 max-w-lg mx-auto space-y-4">
+      <textarea
+        className="w-full p-2 border rounded resize-none"
+        value={text}
+        onChange={(e) => setText(e.target.value.slice(0, 100))}
+        rows={3}
+        placeholder="Share your thought"
+      />
+      <div className="text-right text-sm opacity-70">{text.length}/100</div>
+      <label className="block">Duration: {duration}h</label>
+      <input
+        type="range"
+        min={1}
+        max={24}
+        value={duration}
+        onChange={(e) => setDuration(Number(e.target.value))}
+        className="w-full"
+      />
+      <button
+        className="bg-nightBlue text-white px-4 py-2 rounded disabled:opacity-50"
+        disabled={text.length <= 1}
+        onClick={submit}
+      >
+        Create
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/features/energy-room/EnergyRoom.tsx
+++ b/frontend/src/features/energy-room/EnergyRoom.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState, useRef } from 'react';
+import { useParams } from 'react-router-dom';
+import { useSession } from '../../store/session';
+
+interface EventMeta {
+  id: string;
+  mood: string;
+}
+
+export default function EnergyRoom() {
+  const { eventId } = useParams();
+  const { sessionId, setPresence } = useSession((s) => ({
+    sessionId: s.sessionId,
+    setPresence: s.setPresence,
+  }));
+  const [event, setEvent] = useState<EventMeta | null>(null);
+  const wsRef = useRef<WebSocket>();
+
+  useEffect(() => {
+    if (!eventId) return;
+    fetch(`/api/events/${eventId}`)
+      .then((r) => r.json())
+      .then(setEvent);
+  }, [eventId]);
+
+  useEffect(() => {
+    if (!eventId || !sessionId) return;
+    const ws = new WebSocket(
+      `wss://api.luma/ws/presence?eventId=${eventId}&sid=${sessionId}`,
+    );
+    ws.onmessage = (ev) => {
+      const data = JSON.parse(ev.data);
+      if (data.type === 'presence') {
+        setPresence(eventId, data.count);
+      }
+    };
+    wsRef.current = ws;
+    return () => ws.close();
+  }, [eventId, sessionId, setPresence]);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center">
+      <div className="text-2xl mb-4">Energy Room</div>
+      <div>{event ? event.mood : '...'}</div>
+    </div>
+  );
+}

--- a/frontend/src/features/home/Home.tsx
+++ b/frontend/src/features/home/Home.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { EventCard } from '../../components/EventCard';
+import EmptyState from '../../components/EmptyState';
+
+interface SuggestedEvent {
+  id: string;
+  emoji: string;
+  text: string;
+  expiresIn: number;
+}
+
+export default function Home() {
+  const [data, setData] = useState<SuggestedEvent[] | null>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetch('/api/events/suggested')
+      .then((res) => res.json())
+      .then(setData)
+      .catch(() => setData([]));
+  }, []);
+
+  return (
+    <div className="p-4 space-y-4">
+      {data === null && (
+        <div className="space-y-4">
+          {Array.from({ length: 3 }).map((_, idx) => (
+            <div
+              key={idx}
+              className="bg-gray-200 dark:bg-gray-700 rounded-2xl h-[120px] w-full animate-pulse"
+            />
+          ))}
+        </div>
+      )}
+      {data && data.length > 0 && (
+        <div className="space-y-4">
+          {data.slice(0, 3).map((ev) => (
+            <EventCard
+              key={ev.id}
+              symbol={ev.emoji}
+              text={ev.text}
+              expiresIn={ev.expiresIn}
+              onSendEnergy={() => navigate(`/energy/${ev.id}`)}
+            />
+          ))}
+        </div>
+      )}
+      {data && data.length === 0 && <EmptyState />}
+      <button
+        className="fixed bottom-6 right-6 bg-nightBlue text-white rounded-full w-12 h-12 flex items-center justify-center shadow-lg"
+        onClick={() => navigate('/create')}
+        aria-label="Create"
+      >
+        +
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/features/premium/Premium.tsx
+++ b/frontend/src/features/premium/Premium.tsx
@@ -1,0 +1,8 @@
+export default function Premium() {
+  return (
+    <div className="p-4">
+      <h2 className="text-xl mb-4">Premium</h2>
+      <p>Upgrade coming soon.</p>
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import App from './App';
+import CreateEvent from './features/create-event/CreateEvent';
+import EnergyRoom from './features/energy-room/EnergyRoom';
+import Premium from './features/premium/Premium';
+import Home from './features/home/Home';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <Router>
+      <Routes>
+        <Route path="/" element={<App />}> 
+          <Route index element={<Home />} />
+          <Route path="create" element={<CreateEvent />} />
+          <Route path="energy/:eventId" element={<EnergyRoom />} />
+          <Route path="premium" element={<Premium />} />
+        </Route>
+      </Routes>
+    </Router>
+  </React.StrictMode>,
+);

--- a/frontend/src/store/session.ts
+++ b/frontend/src/store/session.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand';
+import { subscribeWithSelector } from 'zustand/middleware';
+
+export interface MoodConfig {
+  id: string;
+  lottie: string;
+}
+
+export interface SessionState {
+  sessionId: string | null;
+  isPremium: boolean;
+  activeMoods: Record<string, MoodConfig>;
+  presence: { [eventId: string]: number };
+  setPremium: (v: boolean) => void;
+  setPresence: (eventId: string, count: number) => void;
+  initSession: () => Promise<void>;
+}
+
+const storageKey = 'sessionId';
+
+export const useSession = create<SessionState>()(
+  subscribeWithSelector((set, get) => ({
+    sessionId: localStorage.getItem(storageKey),
+    isPremium: false,
+    activeMoods: {},
+    presence: {},
+    setPremium: (v) => set({ isPremium: v }),
+    setPresence: (eventId, count) =>
+      set((s) => ({ presence: { ...s.presence, [eventId]: count } })),
+    initSession: async () => {
+      if (get().sessionId) return;
+      const res = await fetch('/api/sessions', { method: 'POST' });
+      const { sessionId } = await res.json();
+      localStorage.setItem(storageKey, sessionId);
+      set({ sessionId });
+    },
+  }))
+);

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --dawn-sand: #f8f5f2;
+  --night-blue: #001022;
+}

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,0 +1,16 @@
+const colors = require('tailwindcss/colors');
+
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        dawnSand: 'var(--dawn-sand)',
+        nightBlue: 'var(--night-blue)',
+      },
+    },
+  },
+  plugins: [require('@tailwindcss/typography')],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  css: {
+    devSourcemap: true
+  }
+});


### PR DESCRIPTION
## Summary
- bootstrap a new React 18 + Vite frontend
- configure Tailwind with colour variables and dark mode
- add global Zustand session store with init logic
- implement basic Home/Create/Energy room pages and routing

