### PR TITLE
Add Docker compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,27 +12,26 @@ Premium prototype features include:
 
 ## Running
 
-Install the Python dependencies and start the backend:
+Start all services with Docker Compose:
 
 ```bash
-pip install -r requirements.txt
-uvicorn backend.main:app --reload
+scripts/start.sh
 ```
 
-The API is then available at `http://localhost:8000/api`. Create a session with:
+This launches the backend on port `8000`, the frontend on port `8080` and also
+starts PostgreSQL and Redis containers. The API is available at
+`http://localhost:8000/api` and the web interface at
+`http://localhost:8080`.
+
+Stop everything with:
 
 ```bash
-curl -X POST http://localhost:8000/api/session
-```
-
-Serve the frontend from the `public` folder using any static file server, e.g.:
-
-```bash
-python3 -m http.server 8080 -d public
+scripts/stop.sh
 ```
 
 WebSocket connections can be opened at `ws://localhost:8000/ws/presence/{event_id}`.
 
 ## Kubernetes setup
 
-Run `scripts/start.sh` to launch PostgreSQL, Redis and the FastAPI backend in Minikube using Helm. Use `scripts/stop.sh` to tear it down.
+The original Helm chart is still available for deployments on a local Minikube
+cluster.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY backend ./backend
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3.9'
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    environment:
+      - DATABASE_URL=postgresql://luma:luma@postgres:5432/luma
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      - postgres
+      - redis
+    ports:
+      - "8000:8000"
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    depends_on:
+      - backend
+    ports:
+      - "8080:80"
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: luma
+      POSTGRES_USER: luma
+      POSTGRES_PASSWORD: luma
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+volumes:
+  postgres_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+COPY public /usr/share/nginx/html
+

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-minikube start
-helm install luma ../helm/luma
+docker compose up --build
+

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-helm uninstall luma
-minikube stop
+docker compose down
+


### PR DESCRIPTION
## Summary
- containerize backend and frontend separately
- add docker-compose setup with postgres and redis
- update start/stop scripts to use Docker Compose
- document local Docker setup in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `docker compose config` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6871458e567c8331834a2e4a59fa195a