### PR TITLE
Switch to redis asyncio client

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,7 @@ from .routers import events, matching, resonance
 from .middleware import PremiumMiddleware
 from . import models
 import uuid
-import aioredis
+import redis.asyncio as aioredis
 import os
 
 app = FastAPI()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ fastapi
 uvicorn[standard]
 SQLAlchemy
 psycopg2-binary
-aioredis
+redis


### PR DESCRIPTION
## Summary
- replace outdated `aioredis` dependency with `redis` async client
- update import in backend to use `redis.asyncio`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68716352cc948331b4c081f7bd8b4fb4