### PR TITLE
Fix API URLs and refine frontend styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ starts PostgreSQL and Redis containers. The API is available at
 `http://localhost:8000/api` and the web interface at
 `http://localhost:8080`.
 
+The frontend uses the `VITE_API_URL` environment variable to locate the backend.
+When running with Docker Compose this resolves to `http://localhost:8000`.
+If you start the frontend separately, create a `.env` file inside `frontend` with
+`VITE_API_URL=http://localhost:8000`.
+
 Stop everything with:
 
 ```bash

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,0 +1,5 @@
+export const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+
+export function apiFetch(path: string, options?: RequestInit) {
+  return fetch(`${API_BASE}${path}`, options);
+}

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,6 +1,6 @@
 export default function EmptyState() {
   return (
-    <div className="flex flex-col items-center justify-center p-8 opacity-70">
+    <div className="flex flex-col items-center justify-center p-8 opacity-70 text-mistGrey-500">
       <p>No events right now.</p>
       {/* TODO: insert Lottie loop */}
     </div>

--- a/frontend/src/components/EventCard.tsx
+++ b/frontend/src/components/EventCard.tsx
@@ -14,7 +14,7 @@ export const EventCard: FC<EventCardProps> = ({
   onSendEnergy,
 }) => (
   <button
-    className="rounded-2xl shadow-sm bg-dawnSand dark:bg-nightBlue/20 p-6 w-full text-left flex items-center space-x-3"
+    className="rounded-md shadow-ambient hover:shadow-key bg-dawnSand dark:bg-nightBlue/20 p-6 w-full text-left flex items-center space-x-3 transition-shadow"
     onClick={onSendEnergy}
   >
     <span className="text-3xl">{symbol}</span>

--- a/frontend/src/features/create-event/CreateEvent.tsx
+++ b/frontend/src/features/create-event/CreateEvent.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { apiFetch } from '../../api/http';
 
 export default function CreateEvent() {
   const [text, setText] = useState('');
   const navigate = useNavigate();
 
   const submit = async () => {
-    const res = await fetch('/api/events', {
+    const res = await apiFetch('/api/events', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       // backend expects `content`, optional symbol and mood fields
@@ -21,7 +22,7 @@ export default function CreateEvent() {
   return (
     <div role="dialog" className="p-4 max-w-lg mx-auto space-y-4">
       <textarea
-        className="w-full p-2 border rounded resize-none"
+        className="w-full p-2 border rounded-md resize-none bg-dawnSand dark:bg-nightBlue/20"
         value={text}
         onChange={(e) => setText(e.target.value.slice(0, 100))}
         rows={3}
@@ -29,7 +30,7 @@ export default function CreateEvent() {
       />
       <div className="text-right text-sm opacity-70">{text.length}/100</div>
       <button
-        className="bg-nightBlue text-white px-4 py-2 rounded disabled:opacity-50"
+        className="bg-waveTeal-400 text-white px-4 py-2 rounded-md shadow-ambient hover:shadow-key transition-shadow disabled:opacity-50"
         disabled={text.length <= 1}
         onClick={submit}
       >

--- a/frontend/src/features/energy-room/EnergyRoom.tsx
+++ b/frontend/src/features/energy-room/EnergyRoom.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { useSession } from '../../store/session';
+import { apiFetch } from '../../api/http';
 
 interface EventMeta {
   id: string;
@@ -18,7 +19,7 @@ export default function EnergyRoom() {
 
   useEffect(() => {
     if (!eventId) return;
-    fetch(`/api/events/${eventId}`)
+    apiFetch(`/api/events/${eventId}`)
       .then((r) => r.json())
       .then(setEvent);
   }, [eventId]);

--- a/frontend/src/features/home/Home.tsx
+++ b/frontend/src/features/home/Home.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { EventCard } from '../../components/EventCard';
 import EmptyState from '../../components/EmptyState';
+import { apiFetch } from '../../api/http';
 
 interface SuggestedEvent {
   id: string;
@@ -16,7 +17,7 @@ export default function Home() {
 
   useEffect(() => {
     // backend only exposes a simple list endpoint under /api/events
-    fetch('/api/events')
+    apiFetch('/api/events')
       .then((res) => res.json())
       .then((events) =>
         setData(

--- a/frontend/src/store/session.ts
+++ b/frontend/src/store/session.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { apiFetch } from '../api/http';
 import { subscribeWithSelector } from 'zustand/middleware';
 
 export interface MoodConfig {
@@ -30,7 +31,7 @@ export const useSession = create<SessionState>()(
     initSession: async () => {
       if (get().sessionId) return;
       // backend exposes POST /api/session to create a new session
-      const res = await fetch('/api/session', { method: 'POST' });
+      const res = await apiFetch('/api/session', { method: 'POST' });
       const { sessionId } = await res.json();
       localStorage.setItem(storageKey, sessionId);
       set({ sessionId });


### PR DESCRIPTION
## Summary
- use environment variable `VITE_API_URL` for API base
- update fetch calls to use the new helper
- tweak component styles to leverage design tokens
- document the API URL configuration
- provide `.env.example` for frontend

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68716dbb85d08331bd6e9f076fb33179