### PR TITLE
Fix 404 by proxying API paths through nginx

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,4 @@
 FROM nginx:alpine
 COPY public /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,29 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://backend:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    location /ws/ {
+        proxy_pass http://backend:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}


### PR DESCRIPTION
## Summary
- configure nginx to forward `/api` and websocket paths to backend
- copy custom config in frontend Dockerfile

## Testing
- `docker compose config` *(fails: `bash: command not found: docker`)*

------
https://chatgpt.com/codex/tasks/task_e_6871702019548331b415c84dc828b967