### PR TITLE
Add artwork API listing

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,4 +3,5 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY backend ./backend
+COPY public/artwork ./public/artwork
 CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, Depends, APIRouter
 from fastapi.middleware.cors import CORSMiddleware
 from .database import Base, engine, SessionLocal
-from .routers import events, matching, resonance
+from .routers import events, matching, resonance, artwork
 from .middleware import PremiumMiddleware
 from . import models
 import uuid
@@ -27,6 +27,7 @@ api_router = APIRouter()
 api_router.include_router(events.router)
 api_router.include_router(matching.router)
 api_router.include_router(resonance.router)
+api_router.include_router(artwork.router)
 app.include_router(api_router, prefix="/api")
 
 @api_router.post("/session")

--- a/backend/routers/artwork.py
+++ b/backend/routers/artwork.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, HTTPException
+import os
+
+router = APIRouter(prefix="/artwork", tags=["artwork"])
+
+ARTWORK_DIR = os.getenv("ARTWORK_DIR", os.path.join(os.path.dirname(__file__), "..", "..", "public", "artwork"))
+
+@router.get("/")
+def list_artwork():
+    if not os.path.isdir(ARTWORK_DIR):
+        raise HTTPException(status_code=404, detail="artwork directory missing")
+    files = []
+    for root, _, filenames in os.walk(ARTWORK_DIR):
+        for name in filenames:
+            rel = os.path.relpath(os.path.join(root, name), ARTWORK_DIR)
+            files.append("/artwork/" + rel.replace(os.sep, "/"))
+    return files


### PR DESCRIPTION
## Summary
- expose `/api/artwork` endpoint returning available artwork files
- mount the new router in FastAPI
- bundle artwork assets in backend Docker image

## Testing
- `python -m py_compile backend/routers/artwork.py backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6871748815d88331ac8a16284fd1a378