### PR TITLE
Fix session token parsing and websocket connection

### DIFF
--- a/frontend/src/store/session.ts
+++ b/frontend/src/store/session.ts
@@ -31,10 +31,11 @@ export const useSession = create<SessionState>()(
     initSession: async () => {
       if (get().sessionId) return;
       // backend exposes POST /api/session to create a new session
+      // response payload is {"token": "<session token>"}
       const res = await apiFetch('/api/session', { method: 'POST' });
-      const { sessionId } = await res.json();
-      localStorage.setItem(storageKey, sessionId);
-      set({ sessionId });
+      const { token } = await res.json();
+      localStorage.setItem(storageKey, token);
+      set({ sessionId: token });
     },
   }))
 );

--- a/public/components/PresenceIndicator.jsx
+++ b/public/components/PresenceIndicator.jsx
@@ -3,7 +3,11 @@ import { useEffect, useState } from 'react';
 export default function PresenceIndicator({ eventId }) {
   const [count, setCount] = useState(0);
   useEffect(() => {
-    const ws = new WebSocket(`/ws/presence/${eventId}`);
+    const base = (window.API_URL || "http://localhost:8000").replace(
+      /^http/,
+      "ws",
+    );
+    const ws = new WebSocket(`${base}/ws/presence/${eventId}`);
     ws.onmessage = (e) => setCount(JSON.parse(e.data).count);
     return () => ws.close();
   }, [eventId]);


### PR DESCRIPTION
## Summary
- use token returned by backend when creating a session
- connect PresenceIndicator to backend websocket on port 8000

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6872cee8bd048331ad0b7e04f500706f