### PR TITLE
Fix event schema and card controls

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, ConfigDict
 from typing import Optional
+from datetime import datetime
 
 class SessionCreate(BaseModel):
     pass
@@ -15,6 +16,6 @@ class EventCreate(BaseModel):
 class EventOut(EventCreate):
     id: int
     creator_id: int
-    created_at: str
+    created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)

--- a/frontend/src/features/energy-room/EnergyRoom.tsx
+++ b/frontend/src/features/energy-room/EnergyRoom.tsx
@@ -21,7 +21,11 @@ export default function EnergyRoom() {
   return (
     <div className="p-4 flex flex-col items-center">
       <div className="relative w-full max-w-md">
-        <Link to="/" className="absolute right-0 -top-2 text-xl">
+        <Link
+          to="/"
+          aria-label="Close"
+          className="absolute right-2 top-2 text-xl text-white"
+        >
           ×
         </Link>
         <div className="card w-full text-center">{event ? event.content : '...'}</div>


### PR DESCRIPTION
## Summary
- keep API `created_at` as datetime so JSON output is valid string
- make the close button in the energy room white

## Testing
- `python -m py_compile backend/schemas.py`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68739c32833c8331b9951c732640bf8e