### PR TITLE
Fix missing plugin for frontend build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "typescript": "^4.9.3",
     "vite": "^4.0.0",
     "tailwindcss": "^3.3.2",
+    "@tailwindcss/typography": "^0.5.9",
     "postcss": "^8.4.21",
     "autoprefixer": "^10.4.13",
     "eslint": "^8.44.0",


### PR DESCRIPTION
## Summary
- add `@tailwindcss/typography` plugin so the Docker build works

## Testing
- `docker compose build frontend` *(fails: `command not found: docker`)*

------
https://chatgpt.com/codex/tasks/task_e_6874014dd67883319da7f84a3bb0ae45