### PR TITLE
Restore backend hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ scripts/start.sh
 
 This launches the backend on port `8000`, the frontend on port `8080` and also
 starts PostgreSQL and Redis containers. The API is available at
-`http://localhost:8000/api` and the web interface at
+`http://backend:8000/api` and the web interface at
 `http://localhost:8080`.
 
 The frontend uses the `VITE_API_URL` environment variable to locate the backend.
-When running with Docker Compose this resolves to `http://localhost:8000`.
+When running with Docker Compose this resolves to `http://backend:8000`.
 If you start the frontend separately, create a `.env` file inside `frontend` with
-`VITE_API_URL=http://localhost:8000`.
+`VITE_API_URL=http://backend:8000`.
 
 Stop everything with:
 
@@ -34,7 +34,7 @@ Stop everything with:
 scripts/stop.sh
 ```
 
-WebSocket connections can be opened at `ws://localhost:8000/ws/presence/{event_id}`.
+WebSocket connections can be opened at `ws://backend:8000/ws/presence/{event_id}`.
 
 ## Kubernetes setup
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:8000
+VITE_API_URL=http://backend:8000

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,4 +1,4 @@
-export const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+export const API_BASE = import.meta.env.VITE_API_URL || 'http://backend:8000';
 
 export function apiFetch(path: string, options?: RequestInit) {
   return fetch(`${API_BASE}${path}`, options);

--- a/public/app.jsx
+++ b/public/app.jsx
@@ -5,7 +5,7 @@ const { useState, useEffect } = React;
 // port 8000. Using a relative path would hit the frontend server
 // instead of the API and result in 404 errors, so construct the base
 // URL explicitly.
-const API_BASE = (window.API_URL || "http://localhost:8000") + "/api";
+const API_BASE = (window.API_URL || "http://backend:8000") + "/api";
 
 function App() {
   const [events, setEvents] = useState([]);

--- a/public/components/PresenceIndicator.jsx
+++ b/public/components/PresenceIndicator.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 export default function PresenceIndicator({ eventId }) {
   const [count, setCount] = useState(0);
   useEffect(() => {
-    const base = (window.API_URL || "http://localhost:8000").replace(
+    const base = (window.API_URL || "http://backend:8000").replace(
       /^http/,
       "ws",
     );


### PR DESCRIPTION
## Summary
- revert VITE_API_URL to http://backend:8000
- use backend hostname in example env file and code
- document backend URL in README
