### PR TITLE
Make frontend detect backend automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ starts PostgreSQL and Redis containers. The API is available at
 `http://localhost:8080`.
 
 The frontend uses the `VITE_API_URL` environment variable to locate the backend.
-When running with Docker Compose this resolves to `http://backend:8000`.
-If you start the frontend separately, create a `.env` file inside `frontend` with
-`VITE_API_URL=http://backend:8000`.
+If this variable is not set the application falls back to the same hostname on
+port `8000`. When running with Docker Compose the variable is automatically set
+to `http://backend:8000`. For a local setup outside of Docker create a `.env`
+file inside `frontend` with `VITE_API_URL=http://localhost:8000`.
 
 Stop everything with:
 

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,4 +1,6 @@
-export const API_BASE = import.meta.env.VITE_API_URL || 'http://backend:8000';
+const defaultHost = `${window.location.protocol}//${window.location.hostname}:8000`;
+export const API_BASE =
+  import.meta.env.VITE_API_URL || defaultHost;
 
 export function apiFetch(path: string, options?: RequestInit) {
   return fetch(`${API_BASE}${path}`, options);

--- a/public/app.jsx
+++ b/public/app.jsx
@@ -5,7 +5,8 @@ const { useState, useEffect } = React;
 // port 8000. Using a relative path would hit the frontend server
 // instead of the API and result in 404 errors, so construct the base
 // URL explicitly.
-const API_BASE = (window.API_URL || "http://backend:8000") + "/api";
+const defaultHost = `${window.location.protocol}//${window.location.hostname}:8000`;
+const API_BASE = (window.API_URL || defaultHost) + "/api";
 
 function App() {
   const [events, setEvents] = useState([]);

--- a/public/components/PresenceIndicator.jsx
+++ b/public/components/PresenceIndicator.jsx
@@ -3,7 +3,8 @@ import { useEffect, useState } from 'react';
 export default function PresenceIndicator({ eventId }) {
   const [count, setCount] = useState(0);
   useEffect(() => {
-    const base = (window.API_URL || "http://backend:8000").replace(
+    const defaultHost = `${window.location.protocol}//${window.location.hostname}:8000`;
+    const base = (window.API_URL || defaultHost).replace(
       /^http/,
       "ws",
     );


### PR DESCRIPTION
## Summary
- derive default backend URL from current page hostname
- clarify backend URL instructions in README

## Testing
- `npx vite build` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687413ea45ec8331a141e1192a512d16