### PR TITLE
Fix default host when opening frontend directly

### DIFF
--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,6 +1,11 @@
-const defaultHost = `${window.location.protocol}//${window.location.hostname}:8000`;
-export const API_BASE =
-  import.meta.env.VITE_API_URL || defaultHost;
+const protocol =
+  window.location.protocol === 'http:' ||
+  window.location.protocol === 'https:'
+    ? window.location.protocol
+    : 'http:';
+const host = window.location.hostname || 'localhost';
+const defaultHost = `${protocol}//${host}:8000`;
+export const API_BASE = import.meta.env.VITE_API_URL || defaultHost;
 
 export function apiFetch(path: string, options?: RequestInit) {
   return fetch(`${API_BASE}${path}`, options);

--- a/public/app.jsx
+++ b/public/app.jsx
@@ -5,7 +5,12 @@ const { useState, useEffect } = React;
 // port 8000. Using a relative path would hit the frontend server
 // instead of the API and result in 404 errors, so construct the base
 // URL explicitly.
-const defaultHost = `${window.location.protocol}//${window.location.hostname}:8000`;
+const protocol =
+  window.location.protocol === 'http:' || window.location.protocol === 'https:'
+    ? window.location.protocol
+    : 'http:';
+const host = window.location.hostname || 'localhost';
+const defaultHost = `${protocol}//${host}:8000`;
 const API_BASE = (window.API_URL || defaultHost) + "/api";
 
 function App() {

--- a/public/components/PresenceIndicator.jsx
+++ b/public/components/PresenceIndicator.jsx
@@ -3,11 +3,13 @@ import { useEffect, useState } from 'react';
 export default function PresenceIndicator({ eventId }) {
   const [count, setCount] = useState(0);
   useEffect(() => {
-    const defaultHost = `${window.location.protocol}//${window.location.hostname}:8000`;
-    const base = (window.API_URL || defaultHost).replace(
-      /^http/,
-      "ws",
-    );
+    const protocol =
+      window.location.protocol === 'http:' || window.location.protocol === 'https:'
+        ? window.location.protocol
+        : 'http:';
+    const host = window.location.hostname || 'localhost';
+    const defaultHost = `${protocol}//${host}:8000`;
+    const base = (window.API_URL || defaultHost).replace(/^http/, "ws");
     const ws = new WebSocket(`${base}/ws/presence/${eventId}`);
     ws.onmessage = (e) => setCount(JSON.parse(e.data).count);
     return () => ws.close();


### PR DESCRIPTION
## Summary
- adjust default API host logic in the vanilla demo and PWA
- ensure websocket presence indicator handles `file:` URLs

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6874154b373c83319e24bc56ca636d78