### PR TITLE
Add frontend chart and use shared host

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,20 @@ WebSocket connections can be opened at `ws://backend:8000/ws/presence/{event_id}
 
 ## Kubernetes setup
 
-The original Helm chart is still available for deployments on a local Minikube
-cluster.
+Build the container images and deploy the chart to a local cluster. When used
+with Docker Compose the frontend image is built automatically with
+`API_URL=http://backend:8000`. For Kubernetes the API is reachable through the
+Ingress on the same host, so build the frontend with a relative `/api` base
+path:
+
+```bash
+docker build -t luma-backend:latest -f backend/Dockerfile .
+docker build -t luma-frontend:latest \
+  --build-arg API_URL=/api -f frontend/Dockerfile .
+
+helm install luma helm/luma
+```
+
+Add `127.0.0.1 luma.local` to your `/etc/hosts` and run `kubectl port-forward
+svc/luma-frontend 8080:80` to open the web interface at
+`http://luma.local:8080` on macOS.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,16 @@ services:
       - redis
     ports:
       - "8000:8000"
+    networks:
+      default:
+        aliases:
+          - luma-backend
   frontend:
     build:
       context: .
       dockerfile: frontend/Dockerfile
+      args:
+        API_URL: http://backend:8000
     depends_on:
       - backend
     ports:

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -3,6 +3,7 @@
 Use the provided Helm chart to deploy all components:
 
 - FastAPI backend
+- React frontend served by Nginx
 - PostgreSQL
 - Redis
 
@@ -12,4 +13,10 @@ Install with:
 helm install luma helm/luma
 ```
 
-Expose the service using port-forward or ingress. The chart is suitable for local Minikube clusters.
+Expose the service using port-forward or ingress. For local development run:
+
+```bash
+kubectl port-forward svc/luma-frontend 8080:80
+```
+
+The chart is suitable for local Minikube clusters.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,12 @@ WORKDIR /app
 COPY frontend/package.json ./
 RUN npm install
 COPY frontend .
-ENV VITE_API_URL=http://backend:8000
+
+# The API endpoint can be customized during the image build
+# so that the frontend works in different environments.
+ARG API_URL=/api
+ENV VITE_API_URL=$API_URL
+
 RUN npm run build
 
 FROM nginx:alpine

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,7 +8,7 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://backend:8000;
+        proxy_pass http://luma-backend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -18,7 +18,7 @@ server {
     }
 
     location /ws/ {
-        proxy_pass http://backend:8000;
+        proxy_pass http://luma-backend;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/helm/luma/templates/frontend-deployment.yaml
+++ b/helm/luma/templates/frontend-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: luma-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: luma-frontend
+  template:
+    metadata:
+      labels:
+        app: luma-frontend
+    spec:
+      containers:
+      - name: frontend
+        image: {{ .Values.frontend.image }}
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: luma-frontend
+spec:
+  selector:
+    app: luma-frontend
+  ports:
+  - port: 80
+    targetPort: 80

--- a/helm/luma/templates/ingress.yaml
+++ b/helm/luma/templates/ingress.yaml
@@ -11,6 +11,20 @@ spec:
         pathType: Prefix
         backend:
           service:
+            name: luma-frontend
+            port:
+              number: 80
+      - path: /api
+        pathType: Prefix
+        backend:
+          service:
+            name: luma-backend
+            port:
+              number: 80
+      - path: /ws
+        pathType: Prefix
+        backend:
+          service:
             name: luma-backend
             port:
               number: 80

--- a/helm/luma/values.yaml
+++ b/helm/luma/values.yaml
@@ -1,4 +1,6 @@
 image: luma-backend:latest
+frontend:
+  image: luma-frontend:latest
 postgres:
   image: postgres:15
 redis:


### PR DESCRIPTION
## Summary
- allow building frontend image with custom API URL
- proxy frontend traffic to Kubernetes service `luma-backend`
- add frontend deployment/service to Helm chart
- route Ingress to frontend and backend
- add backend alias in Docker Compose
- document Kubernetes usage

## Testing
- `python -m py_compile backend/*.py`
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6874b8275b8c8331888af758542483b9