### PR TITLE
Fix API URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ scripts/start.sh
 
 This launches the backend on port `8000`, the frontend on port `8080` and also
 starts PostgreSQL and Redis containers. The API is available at
-`http://backend:8000/api` and the web interface at
+`http://localhost:8000/api` and the web interface at
 `http://localhost:8080`.
 
 The frontend uses the `VITE_API_URL` environment variable to locate the backend.
 If this variable is not set the application falls back to the same hostname on
 port `8000`. When running with Docker Compose the variable is automatically set
-to `http://backend:8000`. For a local setup outside of Docker create a `.env`
+to `/api`. For a local setup outside of Docker create a `.env`
 file inside `frontend` with `VITE_API_URL=http://localhost:8000`.
 
 Stop everything with:
@@ -35,13 +35,13 @@ Stop everything with:
 scripts/stop.sh
 ```
 
-WebSocket connections can be opened at `ws://backend:8000/ws/presence/{event_id}`.
+WebSocket connections can be opened at `ws://localhost:8080/ws/presence/{event_id}`.
 
 ## Kubernetes setup
 
 Build the container images and deploy the chart to a local cluster. When used
 with Docker Compose the frontend image is built automatically with
-`API_URL=http://backend:8000`. For Kubernetes the API is reachable through the
+`API_URL=/api`. For Kubernetes the API is reachable through the
 Ingress on the same host, so build the frontend with a relative `/api` base
 path:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       context: .
       dockerfile: frontend/Dockerfile
       args:
-        API_URL: http://backend:8000
+        API_URL: /api
     depends_on:
       - backend
     ports:


### PR DESCRIPTION
## Summary
- fix the build argument for the frontend service
- update README to use `/api` as the default base
- document websocket endpoint through the frontend

## Testing
- `npm --version` *(fails: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6874ce81b10c8331877e1930596254fd