### PR TITLE
Fix API base URL logic in frontend

### DIFF
--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -5,7 +5,8 @@ const protocol =
     : 'http:';
 const host = window.location.hostname || 'localhost';
 const defaultHost = `${protocol}//${host}:8000`;
-export const API_BASE = import.meta.env.VITE_API_URL || defaultHost;
+const base = import.meta.env.VITE_API_URL || defaultHost;
+export const API_BASE = base.endsWith('/api') ? base : `${base}/api`;
 
 export function apiFetch(path: string, options?: RequestInit) {
   return fetch(`${API_BASE}${path}`, options);

--- a/frontend/src/features/create-event/CreateEvent.tsx
+++ b/frontend/src/features/create-event/CreateEvent.tsx
@@ -7,7 +7,7 @@ export default function CreateEvent() {
   const navigate = useNavigate();
 
   const submit = async () => {
-    const res = await apiFetch('/api/events', {
+    const res = await apiFetch('/events', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       // backend expects `content`, optional symbol and mood fields

--- a/frontend/src/features/energy-room/EnergyRoom.tsx
+++ b/frontend/src/features/energy-room/EnergyRoom.tsx
@@ -13,7 +13,7 @@ export default function EnergyRoom() {
 
   useEffect(() => {
     if (!eventId) return;
-    apiFetch(`/api/events/${eventId}`)
+    apiFetch(`/events/${eventId}`)
       .then((r) => r.json())
       .then(setEvent);
   }, [eventId]);

--- a/frontend/src/features/home/Home.tsx
+++ b/frontend/src/features/home/Home.tsx
@@ -17,8 +17,8 @@ export default function Home() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // backend only exposes a simple list endpoint under /api/events
-    apiFetch('/api/events')
+    // backend only exposes a simple list endpoint under /events
+    apiFetch('/events')
       .then((res) => res.json())
       .then((events) =>
         setData(

--- a/frontend/src/store/session.ts
+++ b/frontend/src/store/session.ts
@@ -30,9 +30,9 @@ export const useSession = create<SessionState>()(
       set((s) => ({ presence: { ...s.presence, [eventId]: count } })),
     initSession: async () => {
       if (get().sessionId) return;
-      // backend exposes POST /api/session to create a new session
+      // backend exposes POST /session to create a new session
       // response payload is {"token": "<session token>"}
-      const res = await apiFetch('/api/session', { method: 'POST' });
+      const res = await apiFetch('/session', { method: 'POST' });
       const { token } = await res.json();
       localStorage.setItem(storageKey, token);
       set({ sessionId: token });


### PR DESCRIPTION
## Summary
- append `/api` automatically in the API base helper
- update API calls to use the new base

## Testing
- `pytest -q` *(fails: no tests)*
- `npm --prefix frontend run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874d6b6db4c8331b5bbf39ce0a96398