### PR TITLE
Add seed events on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ starts PostgreSQL and Redis containers. The API is available at
 `http://localhost:8000/api` and the web interface at
 `http://localhost:8080`.
 
+On startup the backend populates the database with a few sample events so that
+the main page immediately shows three example cards.
+
 The frontend uses the `VITE_API_URL` environment variable to locate the backend.
 If this variable is not set the application falls back to the same hostname on
 port `8000`. When running with Docker Compose the variable is automatically set

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,43 @@ app.add_middleware(
 
 Base.metadata.create_all(bind=engine)
 
+
+def seed_data():
+    """Populate the database with a few default events."""
+    db = SessionLocal()
+    try:
+        # Only seed when the tables are empty
+        if db.query(models.Event).count() > 0:
+            return
+
+        # create a session to own the seed events
+        seed_session = models.Session(token="seed")
+        db.add(seed_session)
+        db.commit()
+        db.refresh(seed_session)
+
+        default_events = [
+            {"symbol": "🌅", "content": "Watch the sunrise"},
+            {"symbol": "😊", "content": "Smile at a stranger"},
+            {"symbol": "🎵", "content": "Listen to your favorite song"},
+        ]
+
+        for ev in default_events:
+            db_event = models.Event(
+                creator_id=seed_session.id,
+                mood=None,
+                symbol=ev["symbol"],
+                content=ev["content"],
+            )
+            db.add(db_event)
+
+        db.commit()
+    finally:
+        db.close()
+
+
+seed_data()
+
 redis = aioredis.from_url(os.getenv("REDIS_URL", "redis://localhost"))
 
 # group all API routes under /api


### PR DESCRIPTION
## Summary
- seed the database with three events on app start
- document automatic seed data in the README

## Testing
- `python -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6876030ca47483319e56d782d46f02ef