### PR TITLE
Show event text in EnergyRoom

### DIFF
--- a/frontend/src/features/energy-room/EnergyRoom.tsx
+++ b/frontend/src/features/energy-room/EnergyRoom.tsx
@@ -1,21 +1,25 @@
 import { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useLocation } from 'react-router-dom';
 import { apiFetch } from '../../api/http';
 
 interface EventMeta {
   id: string;
   mood: string;
+  content: string;
 }
 
 export default function EnergyRoom() {
   const { eventId } = useParams();
-  const [event, setEvent] = useState<EventMeta | null>(null);
+  const location = useLocation();
+  const [content, setContent] = useState<string>(
+    (location.state as { text?: string } | null)?.text || ''
+  );
 
   useEffect(() => {
     if (!eventId) return;
     apiFetch(`/events/${eventId}`)
       .then((r) => r.json())
-      .then(setEvent);
+      .then((data: EventMeta) => setContent(data.content));
   }, [eventId]);
 
   return (
@@ -28,8 +32,12 @@ export default function EnergyRoom() {
         >
           ×
         </Link>
-        <div className="card w-full text-center">{event ? event.content : '...'}</div>
-        <p className="text-center mt-4">You are now in this moment</p>
+        <div className="card w-full text-center">
+          <p className="card-title">{content || '...'}</p>
+          <p className="text-xs text-gray-400 mt-2">
+            3 people are with you in this moment.
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/features/home/Home.tsx
+++ b/frontend/src/features/home/Home.tsx
@@ -28,7 +28,9 @@ export default function Home() {
               key={ev.id}
               text={ev.text}
               expiresIn={ev.expiresIn}
-              onSendEnergy={() => navigate(`/energy/${ev.id}`)}
+              onSendEnergy={() =>
+                navigate(`/energy/${ev.id}`, { state: { text: ev.text } })
+              }
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- pass card text when navigating to the energy room
- display the text immediately in the energy room
- show participant count in small grey text

## Testing
- `npm install` *(fails: registry.npmjs.org blocked)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876372dbb988331bbc4bf91973b87f2