### PR TITLE
Fix events endpoint and update seed data

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -38,16 +38,16 @@ def seed_data():
         db.refresh(seed_session)
 
         default_events = [
-            {"symbol": "🌅", "content": "Watch the sunrise"},
-            {"symbol": "😊", "content": "Smile at a stranger"},
-            {"symbol": "🎵", "content": "Listen to your favorite song"},
+            {"content": "I have a difficult exam tomorrow."},
+            {"content": "I am afraid to go home tonight."},
+            {"content": "Missing my parents."},
         ]
 
         for ev in default_events:
             db_event = models.Event(
                 creator_id=seed_session.id,
                 mood=None,
-                symbol=ev["symbol"],
+                symbol=None,
                 content=ev["content"],
             )
             db.add(db_event)

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -14,7 +14,7 @@ def get_db():
     finally:
         db.close()
 
-@router.post("/", response_model=schemas.EventOut)
+@router.post("", response_model=schemas.EventOut)
 def create_event(event: schemas.EventCreate, session_token: str, db: Session = Depends(get_db)):
     session = db.query(models.Session).filter_by(token=session_token).first()
     if not session:
@@ -25,7 +25,7 @@ def create_event(event: schemas.EventCreate, session_token: str, db: Session = D
     db.refresh(db_event)
     return db_event
 
-@router.get("/", response_model=list[schemas.EventOut])
+@router.get("", response_model=list[schemas.EventOut])
 def list_events(db: Session = Depends(get_db)):
     return db.query(models.Event).all()
 


### PR DESCRIPTION
## Summary
- make `/api/events` endpoint accessible without trailing slash
- seed new default events

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687647e6500c8331aaf476b0599134d3