### PR TITLE
Update card layout and add 'More moments' link

### DIFF
--- a/frontend/src/components/EventCard.tsx
+++ b/frontend/src/components/EventCard.tsx
@@ -12,7 +12,7 @@ export const EventCard: FC<EventCardProps> = ({
   onSendEnergy,
 }) => (
   <button
-    className="card w-64 h-64 text-center space-y-2 transition-transform hover:shadow-key active:scale-95"
+    className="card w-full aspect-square mx-2 text-center space-y-2 transition-transform hover:shadow-key active:scale-95"
     onClick={onSendEnergy}
   >
     <p className="card-title">{text}</p>

--- a/frontend/src/features/home/Home.tsx
+++ b/frontend/src/features/home/Home.tsx
@@ -24,7 +24,7 @@ export default function Home() {
   }, []);
 
   return (
-    <div className="p-4 space-y-4 flex flex-col items-center">
+    <div className="relative p-4 space-y-4 flex flex-col items-center min-h-screen">
       {data && data.length > 0 && (
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 w-full max-w-5xl justify-items-center">
           {data.slice(0, page * 3).map((ev) => (
@@ -41,11 +41,11 @@ export default function Home() {
       )}
       {data && page * 3 < (data?.length ?? 0) && (
         <button
-          className="mt-4 text-black"
+          className="absolute bottom-4 text-sm text-gray-600"
           onClick={() => setPage((p) => p + 1)}
-          aria-label="More"
+          aria-label="More moments"
         >
-          ↓
+          More moments
         </button>
       )}
     </div>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -84,8 +84,9 @@ body {
   background-size: cover;
   border-radius: 18px;
   padding: 24px;
-  max-width: 90%;
-  margin: 0 auto;
+  width: 100%;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
   color: var(--text-day);
   font-family: 'Inter', sans-serif;
   aspect-ratio: 1 / 1;


### PR DESCRIPTION
## Summary
- enlarge EventCard and make it square
- show `More moments` link on Home page
- tweak global card styles for full width and small margins

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880ba6d874c8331ac01c66c2a649d72